### PR TITLE
Added 'next' to _TIMEFRAME_DIVSPLIT

### DIFF
--- a/pyEX/common.py
+++ b/pyEX/common.py
@@ -29,7 +29,7 @@ _SSE_URL_PREFIX_ALL = 'https://cloud-sse.iexapis.com/{version}/{channel}?token={
 _SSE_DEEP_URL_PREFIX = 'https://cloud-sse.iexapis.com/{version}/deep?symbols={symbols}&channels={channels}&token={token}'
 
 _TIMEFRAME_CHART = ['5y', '2y', '1y', 'ytd', '6m', '3m', '1m', '1d']
-_TIMEFRAME_DIVSPLIT = ['5y', '2y', '1y', 'ytd', '6m', '3m', '1m']
+_TIMEFRAME_DIVSPLIT = ['5y', '2y', '1y', 'ytd', '6m', '3m', '1m', 'next']
 _LIST_OPTIONS = ['mostactive', 'gainers', 'losers', 'iexvolume', 'iexpercent']
 _COLLECTION_TAGS = ['sector', 'tag', 'list']
 


### PR DESCRIPTION
/dividends and /splits support 'next' as a valid timeframe.

https://iexcloud.io/docs/api/#dividends
https://iexcloud.io/docs/api/#splits

/splits/next appears to generate a 404 page for all symbols as opposed to an empty list, but in the IEX documentation it should work.