### PR TITLE
Correct a typo in the url for ref-data/mutual-funds/symbols.

### DIFF
--- a/pyEX/refdata.py
+++ b/pyEX/refdata.py
@@ -281,7 +281,7 @@ def mutualFundSymbols(token='', version='', filter=''):
     Returns:
         dict: result
     '''
-    return _getJson('ref-data/mutual-fund/symbols', token, version, filter)
+    return _getJson('ref-data/mutual-funds/symbols', token, version, filter)
 
 
 @_expire(hour=8)


### PR DESCRIPTION
Corrected url found at https://iexcloud.io/docs/api/#mutual-fund-symbols